### PR TITLE
Use ==/!= to compare str, bytes, and int literals

### DIFF
--- a/segmentron/solver/lovasz_losses.py
+++ b/segmentron/solver/lovasz_losses.py
@@ -185,7 +185,7 @@ def lovasz_softmax_flat(probas, labels, classes='present'):
     class_to_sum = list(range(C)) if classes in ['all', 'present'] else classes
     for c in class_to_sum:
         fg = (labels == c).float()  # foreground for class c
-        if (classes is 'present' and fg.sum() == 0):
+        if classes == 'present' and fg.sum() == 0:
             continue
         if C == 1:
             if len(classes) > 1:


### PR DESCRIPTION
Identity is not the same thing as equality in Python so use ==/!= to compare str, bytes, and int literals. In Python >= 3.8, these instances will raise __SyntaxWarnings__ so it is best to fix them now. https://docs.python.org/3.8/whatsnew/3.8.html#porting-to-python-3-8

% __python__
```
>>> classes = "pres"
>>> classes += "ent"
>>> classes == "present"
True
>>> classes is "present"
False
>>> 1 == 1.0
True
>>> 1 is 1.0
False
```